### PR TITLE
Do not trigger E_WARNING when rendering table without rows

### DIFF
--- a/src/Tcpdf/Extension/Table/Table.php
+++ b/src/Tcpdf/Extension/Table/Table.php
@@ -15,7 +15,7 @@ class Table
     private $pdf;
     private $pageBreakCallback;
     private $cacheDir;
-    private $rows;
+    private $rows = array();
     private $borderWidth;
     private $lineHeight = 1;
     private $fontFamily;


### PR DESCRIPTION
Thank you for excellent extension!

This pull request fixes `Invalid argument supplied for foreach()` at TableConverter::_getRawCellWidths() when no rows added to table.