### PR TITLE
Removed the 'dev-master' requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.8",
-        "tecnickcom/tcpdf": "dev-master"
+        "tecnickcom/tcpdf": "6.2.*"
     },
     "autoload": {
         "psr-0" : { "Tcpdf\\Extension\\" : "src/" }


### PR DESCRIPTION
Requirement of the dev-master tag causes a conflict when trying to use 'setasign/fpdi-tcpdf' at the same time, as Fpdi requires 6.2.*